### PR TITLE
feat!(spawn-local-jdk): Optimizes JDKDetector to use JDK meta-data-based and glob patterns

### DIFF
--- a/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKDetector.java
+++ b/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKDetector.java
@@ -20,17 +20,14 @@ package build.spawn.platform.local.jdk;
  * #L%
  */
 
-import build.base.flow.CompletingSubscriber;
+import build.base.foundation.Exceptional;
 import build.base.logging.Logger;
 import build.base.option.JDKVersion;
-import build.spawn.application.Application;
-import build.spawn.application.Console;
-import build.spawn.application.option.Argument;
-import build.spawn.application.option.StandardErrorSubscriber;
 import build.spawn.jdk.JDK;
 import build.spawn.jdk.option.JDKHome;
-import build.spawn.platform.local.LocalMachine;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -45,6 +42,20 @@ import java.util.stream.Stream;
  * @since Nov-2019
  */
 public interface JDKDetector {
+
+    /**
+     * Obtains a {@link Stream} of candidate {@link java.nio.file.Path}s for {@link JDK} installations,
+     * based on OS-specific glob patterns — without launching any subprocesses to verify them.
+     * <p>
+     * This is the cheap, fast phase of detection. Callers that only need to know whether any
+     * {@link JDK}s are likely present (e.g. capability checks) should prefer this over
+     * {@link #detect()}, which reads each candidate's {@code release} metadata file.
+     *
+     * @return a {@link Stream} of candidate {@link java.nio.file.Path}s
+     */
+    default Stream<Path> paths() {
+        return Stream.empty();
+    }
 
     /**
      * Obtains a {@link Stream} of the available {@link JDK}s.
@@ -83,16 +94,16 @@ public interface JDKDetector {
     }
 
     /**
-     * Attempts to create {@link JDK} based on the specified {@link Path} to Java Home by testing its availability
-     * and that it's operational.
+     * Attempts to create a {@link JDK} for the specified {@link Path} to a Java Home by reading its
+     * {@code release} metadata file.
      * <p>
-     * Should specified {@link Path} refer to a Java Runtime Environment (JRE), and attempt will be made to
+     * Should the specified {@link Path} refer to a Java Runtime Environment (JRE), an attempt will be made to
      * locate the {@link JDK} based on the specified {@link Path}.
      *
      * @param path the {@link Path}
-     * @return the {@link Optional} operational and available {@link JDK}, otherwise {@link Optional#empty()}
+     * @return the {@link Exceptional} {@link JDK}, otherwise {@link Exceptional#empty()}
      */
-    static Optional<JDK> of(final Path path) {
+    static Exceptional<JDK> of(final Path path) {
         final var LOGGER = Logger.get(JDKDetector.class);
 
         // use provided path as the basis of the JDK location
@@ -100,7 +111,7 @@ public interface JDKDetector {
 
         // ensure the path exists
         if (!home.toFile().exists()) {
-            return Optional.empty();
+            return Exceptional.empty();
         }
 
         if (home.endsWith("jre")) {
@@ -110,105 +121,47 @@ public interface JDKDetector {
 
         if (!home.resolve("bin/java").toFile().exists()) {
             LOGGER.warn("The JDK Home [{0}] does not contain bin/java", home);
-            return Optional.empty();
+            return Exceptional.empty();
         }
 
-        // attempt to execute "java -version" on the LocalMachine to prove that it's installed and detect the version
-        final var machine = LocalMachine.get();
-        final var executable = home.resolve("bin/java").toString();
+        // read the release file to determine the JDK version — no subprocess needed
+        final Path releaseFile = home.resolve("release");
+        if (!releaseFile.toFile().exists()) {
+            LOGGER.warn("The JDK Home [{0}] does not contain a release file", home);
+            return Exceptional.empty();
+        }
 
-        // a Pattern to match the java version line output by java
-        final var VERSION = Pattern.compile("(?:java|openjdk) version \"(.+?)\".*");
-        final var subscriber = new CompletingSubscriber<String>();
-        final var version = subscriber.when(line -> VERSION.matcher(line).matches());
+        // a Pattern to match JAVA_VERSION="..." in the release file
+        final var VERSION = Pattern.compile("JAVA_VERSION=\"(.+?)\"");
 
-        try (Application application = machine.launch(executable,
-            Argument.of("-version"),
-            StandardErrorSubscriber.of(subscriber))) {
+        try {
+            final var releaseContent = Files.readString(releaseFile);
+            final var matcher = VERSION.matcher(releaseContent);
 
-            // wait for the application to terminate
-            application.onExit()
-                .join();
+            if (matcher.find()) {
+                final var javaVersion = JDKVersion.of(matcher.group(1));
+                final var javaHome = JDKHome.of(home.toString());
 
-            // iff we detected a version can we create a JDK
-            if (version.isDone() && !version.isCompletedExceptionally() && !version.isCancelled()) {
-                // determine the captured JavaVersion
-                final var matcher = VERSION.matcher(version.get());
-
-                // ensure (again) that it's matched
-                if (matcher.matches()) {
-                    //establish the JDK based on the home and version
-                    final var javaVersion = JDKVersion.of(matcher.group(1));
-                    final var javaHome = JDKHome.of(home.toString());
-
-                    return Optional.of(JDK.of(javaVersion, javaHome));
-                }
+                return Exceptional.of(JDK.of(javaVersion, javaHome));
             }
             else {
-                LOGGER.warn(
-                    "The version of the JDK at [{0}] could not be detected. This installation will be ignored.", home);
+                LOGGER.warn("Could not detect Java version from release file at [{0}]", releaseFile);
+                return Exceptional.empty();
             }
         }
-        catch (final Exception e) {
-            LOGGER.warn("Failed to execute bin/java in [{0}]", home, e);
+        catch (final IOException e) {
+            LOGGER.warn("Failed to read release file at [{0}]", releaseFile, e);
+            return Exceptional.ofException(e);
         }
-
-        return Optional.empty();
     }
 
     /**
-     * Attempts to detect the locally installed operating system default {@link JDK}, by executing
-     * {@code java -XshowSettings:properties -version}
+     * Attempts to detect the default {@link JDK} for the currently running virtual machine by reading its
+     * {@code release} metadata file from {@code java.home}.
      *
-     * @return the {@link Optional} local {@link JDK}, otherwise {@link Optional#empty()} if it can't be detected
+     * @return the {@link Optional} default {@link JDK}, otherwise {@link Optional#empty()} if it can't be detected
      */
     static Optional<JDK> detectDefault() {
-        final var LOGGER = Logger.get(JDKDetector.class);
-
-        final var machine = LocalMachine.get();
-        final var executable = "java";
-
-        final var subscriber = new CompletingSubscriber<String>();
-
-        final var HOME_PREFIX = "java.home = ";
-        final var home = subscriber.when(line -> line.trim().startsWith(HOME_PREFIX), String::trim);
-
-        final var VERSION_PREFIX = "java.version = ";
-        final var version = subscriber.when(line -> line.trim().startsWith(VERSION_PREFIX), String::trim);
-
-        try (Application application = machine.launch(
-            executable,
-            Argument.of("-XshowSettings:properties"),
-            Argument.of("-version"),
-            StandardErrorSubscriber.of(subscriber))) {
-
-            application.onExit()
-                .join();
-
-            if (home.isDone() && !home.isCancelled() && !home.isCompletedExceptionally()) {
-                // obtain the JDKHome from the captured output
-                final var jdkHome = JDKHome.of(home.get().substring(HOME_PREFIX.length()));
-
-                // should we have also captured the JDKVersion, we can use that to create the JDK
-                if (version.isDone() && !version.isCancelled() && !version.isCompletedExceptionally()) {
-                    // obtain the JDKVersion from the captured output
-                    final var jdkVersion = JDKVersion.of(version.get().substring(VERSION_PREFIX.length()));
-
-                    // use the JavaHome to detect the JDK
-                    return Optional.of(JDK.of(jdkVersion, jdkHome));
-                }
-                else {
-                    // attempt to use JDK to detect the JDK
-                    return of(jdkHome.path());
-                }
-            }
-
-            return Optional.empty();
-        }
-        catch (final Exception e) {
-            LOGGER.error("Failed to determine the default JDK installation", e);
-
-            return Optional.empty();
-        }
+        return of(Path.of(System.getProperty("java.home"))).optional();
     }
 }

--- a/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
+++ b/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
@@ -20,9 +20,12 @@ package build.spawn.platform.local.jdk;
  * #L%
  */
 
+import build.base.expression.Processor;
+import build.base.expression.Variable;
+import build.base.foundation.Exceptional;
 import build.base.logging.Logger;
-import build.base.option.JDKVersion;
 import build.spawn.jdk.JDK;
+import com.google.auto.service.AutoService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,14 +42,11 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-
-import com.google.auto.service.AutoService;
 
 /**
  * A {@link JDKDetector} that uses the properties defined by the
@@ -70,7 +70,7 @@ public class JDKHomeBasedPatternDetector
     private static final String JAVA_HOME_PROPERTIES = "java.home.properties";
 
     /**
-     * A cache of the detected {@link JDK}s, ordering them implicitly by {@link JDKVersion}.
+     * A cache of the detected {@link JDK}s, ordering them implicitly by {@link build.base.option.JDKVersion}.
      */
     private final AtomicReference<SortedSet<JDK>> jdks;
 
@@ -82,6 +82,127 @@ public class JDKHomeBasedPatternDetector
     }
 
     @Override
+    public Stream<Path> paths() {
+
+        // establish the JEL processor to expand ${user.home} in glob patterns
+        final var processor = Processor.create(Variable.of("user.home", System.getProperty("user.home", "")));
+
+        try {
+            // use the known jdk homes properties file as the basis of JavaHome locations
+            final Properties knownJdkHomes = new Properties();
+
+            // load the jdk homes
+            final InputStream inputStream =
+                ClassLoader.getSystemResourceAsStream(JAVA_HOME_PROPERTIES);
+
+            knownJdkHomes.load(inputStream);
+
+            // map each of the java homes into a path — no subprocess verification
+            return knownJdkHomes.stringPropertyNames().stream()
+                .filter(key -> {
+                    // keys must have an @ prefix: <os-pattern>@<unique-name>
+                    // keys without @ are excluded
+                    final int at = key.indexOf('@');
+                    if (at < 0) {
+                        return false;
+                    }
+                    final var osPattern = key.substring(0, at);
+                    return matchesOS(System.getProperty("os.name", ""), osPattern);
+                })
+                .map(knownJdkHomes::getProperty)
+                .map(processor::replace)
+                .flatMap(pattern -> {
+                    try {
+                        if (pattern.contains("*") || pattern.contains("?") || pattern.contains("[")
+                            || pattern.contains("]") || pattern.contains("{") || pattern.contains("}")) {
+
+                            // find the position of the last file.separator (/) before a glob pattern
+                            // this will be the base path and the rest is the glob pattern
+                            int i = 0;
+                            int lastPathSeparator = -1;
+                            while (i < pattern.length() && pattern.charAt(i) != '*'
+                                && pattern.charAt(i) != '?' && pattern.charAt(i) != '['
+                                && pattern.charAt(i) != ']' && pattern.charAt(i) != '{'
+                                && pattern.charAt(i) != '}') {
+
+                                if (pattern.charAt(i) == '/') {
+                                    lastPathSeparator = i;
+                                }
+
+                                i++;
+                            }
+
+                            if (lastPathSeparator < 0) {
+                                LOG.warn("The path [{0}] is not an absolute path", pattern);
+                                return Stream.empty();
+                            } else {
+                                final Path base = Paths.get(pattern.substring(0, lastPathSeparator));
+                                final String glob = "glob:" + pattern;
+
+                                // walk the tree from the base to find paths matching the glob
+                                final PathMatcher pathMatcher = FileSystems.getDefault()
+                                    .getPathMatcher(glob);
+
+                                final ArrayList<Path> paths = new ArrayList<>();
+
+                                // attempt to find paths matching the glob, iff the base path exists
+                                if (base.toFile().exists()) {
+                                    Files.walkFileTree(
+                                        base,
+                                        EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+                                        Integer.MAX_VALUE,
+                                        new SimpleFileVisitor<Path>() {
+                                            @Override
+                                            public FileVisitResult preVisitDirectory(final Path path,
+                                                                                     final BasicFileAttributes attrs) {
+                                                if (pathMatcher.matches(path)) {
+                                                    paths.add(path);
+
+                                                    return FileVisitResult.SKIP_SUBTREE;
+                                                } else {
+                                                    return FileVisitResult.CONTINUE;
+                                                }
+                                            }
+
+                                            @Override
+                                            public FileVisitResult visitFileFailed(final Path file,
+                                                                                   final IOException exc)
+                                                throws IOException {
+                                                if (exc instanceof AccessDeniedException) {
+                                                    LOG.debug(
+                                                        "Access denied visiting [{0}], skipping", file);
+                                                    return FileVisitResult.CONTINUE;
+                                                }
+                                                return super.visitFileFailed(file, exc);
+                                            }
+                                        });
+
+                                    return paths.stream();
+                                } else {
+                                    LOG.debug(
+                                        "Skipping path [{0}] for pattern [{1}] as the path does not exist",
+                                        base, pattern);
+                                    return Stream.empty();
+                                }
+                            }
+                        } else {
+                            return Stream.of(Paths.get(pattern));
+                        }
+                    } catch (final InvalidPathException e) {
+                        LOG.debug("The path [{0}] is not a valid pattern", pattern);
+                        return Stream.empty();
+                    } catch (final IOException e) {
+                        LOG.debug("Failed to visit a path [{0}]", pattern, e);
+                        return Stream.empty();
+                    }
+                });
+        } catch (final IOException e) {
+            LOG.error("Failed to read {0}", JAVA_HOME_PROPERTIES, e);
+            return Stream.empty();
+        }
+    }
+
+    @Override
     public Stream<JDK> detect() {
 
         // detect the installed JDKs once
@@ -90,133 +211,44 @@ public class JDKHomeBasedPatternDetector
                 // we've yet to detect the installed JDKs
 
                 // the currently detected JDKs
-                // (we perform detection concurrently, so it has to be thread-safe)
                 final SortedSet<JDK> detected = new ConcurrentSkipListSet<>();
 
-                try {
-                    // use the known jdk homes properties file as the basis of JavaHome locations
-                    final Properties knownJdkHomes = new Properties();
-
-                    // load the jdk homes
-                    final InputStream inputStream =
-                        ClassLoader.getSystemResourceAsStream(JAVA_HOME_PROPERTIES);
-
-                    knownJdkHomes.load(inputStream);
-
-                    // map each of the java homes into a path and determine the JDK from the path
-                    knownJdkHomes.stringPropertyNames().stream()
-                        .map(knownJdkHomes::getProperty)
-                        .flatMap(pattern -> {
-                            try {
-                                if (pattern.contains("*") || pattern.contains("?") || pattern.contains("[")
-                                    || pattern.contains("]") || pattern.contains("{") || pattern.contains(
-                                    "}")) {
-
-                                    // find the position of the last file.separator (/) before a glob pattern
-                                    // this will be the base path and the rest is the glob pattern
-                                    int i = 0;
-                                    int lastPathSeparator = -1;
-                                    while (i < pattern.length() && pattern.charAt(i) != '*'
-                                        && pattern.charAt(i) != '?' && pattern.charAt(i) != '['
-                                        && pattern.charAt(i) != ']' && pattern.charAt(i) != '{'
-                                        && pattern.charAt(i) != '}') {
-
-                                        if (pattern.charAt(i) == '/') {
-                                            lastPathSeparator = i;
-                                        }
-
-                                        i++;
-                                    }
-
-                                    if (lastPathSeparator < 0) {
-                                        LOG.warn("The path [{0}] is not an absolute path", pattern);
-                                        return Stream.empty();
-                                    }
-                                    else {
-                                        final Path base = Paths.get(pattern.substring(0, lastPathSeparator));
-                                        final String glob = "glob:" + pattern;
-
-                                        // walk the tree from the base to find paths matching the glob
-                                        final PathMatcher pathMatcher = FileSystems.getDefault()
-                                            .getPathMatcher(glob);
-
-                                        final ArrayList<Path> paths = new ArrayList<>();
-
-                                        // attempt to find paths matching the glob, iff the base path exists
-                                        if (base.toFile().exists()) {
-                                            Files.walkFileTree(
-                                                base,
-                                                EnumSet.of(FileVisitOption.FOLLOW_LINKS),
-                                                Integer.MAX_VALUE,
-                                                new SimpleFileVisitor<Path>() {
-                                                    @Override
-                                                    public FileVisitResult preVisitDirectory(final Path path,
-                                                                                             final BasicFileAttributes attrs) {
-                                                        if (pathMatcher.matches(path)) {
-                                                            paths.add(path);
-
-                                                            return FileVisitResult.SKIP_SUBTREE;
-                                                        }
-                                                        else {
-                                                            return FileVisitResult.CONTINUE;
-                                                        }
-                                                    }
-
-                                                    @Override
-                                                    public FileVisitResult visitFileFailed(final Path file,
-                                                                                           final IOException exc)
-                                                        throws IOException {
-                                                        if (exc instanceof AccessDeniedException) {
-                                                            LOG.debug(
-                                                                "Failed to access a file: " + file.toString(),
-                                                                exc);
-                                                            return FileVisitResult.CONTINUE;
-                                                        }
-                                                        return super.visitFileFailed(file, exc);
-                                                    }
-                                                });
-
-                                            return paths.stream();
-                                        }
-                                        else {
-                                            LOG.debug(
-                                                "Skipping path [{0}] for pattern [{1}] as the path does not exist",
-                                                base, pattern);
-                                            return Stream.empty();
-                                        }
-                                    }
-                                }
-                                else {
-                                    return Stream.of(Paths.get(pattern));
-                                }
-                            }
-                            catch (final InvalidPathException e) {
-                                LOG.debug("The path [{0}] is not a valid pattern", pattern);
-                                return Stream.empty();
-                            }
-                            catch (final IOException e) {
-                                LOG.debug("Failed to visit a path [{0}]", pattern, e);
-                                return Stream.empty();
-                            }
-                        })
-                        .parallel()
-                        .map(JDKDetector::of)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .forEach(detected::add);
-                }
-                catch (final IOException e) {
-                    LOG.error("Failed to read {0}", JAVA_HOME_PROPERTIES, e);
-                }
+                paths()
+                    .map(JDKDetector::of)
+                    .filter(Exceptional::isPresent)
+                    .map(Exceptional::orElseThrow)
+                    .forEach(detected::add);
 
                 return detected;
-            }
-            else {
+            } else {
                 // use the previously detected JDKs
                 return jdk;
             }
         });
 
         return this.jdks.get().stream();
+    }
+
+    /**
+     * Determines if the specified OS pattern matches the provided OS name.
+     * <p>
+     * Known OS kind patterns: {@code mac}, {@code windows}, {@code unix}, {@code posix}, {@code unknown}.
+     * Any other pattern is treated as a regular expression matched against the OS name (lower-case).
+     *
+     * @param osName  the OS name (typically from {@code System.getProperty("os.name")})
+     * @param pattern the OS pattern from the properties file key prefix
+     * @return {@code true} if the pattern matches the OS name
+     */
+    static boolean matchesOS(final String osName, final String pattern) {
+        final String lower = osName.toLowerCase();
+        return switch (pattern.toLowerCase()) {
+            case "mac" -> lower.contains("mac");
+            case "windows" -> lower.contains("windows");
+            case "unix" -> lower.contains("linux") || lower.contains("freebsd") || lower.contains("openbsd");
+            case "posix" -> lower.contains("sunos") || lower.contains("solaris")
+                || lower.contains("hp-ux") || lower.contains("aix");
+            case "unknown" -> false;
+            default -> lower.matches(pattern.toLowerCase());
+        };
     }
 }

--- a/spawn-local-jdk/src/main/java/module-info.java
+++ b/spawn-local-jdk/src/main/java/module-info.java
@@ -26,6 +26,8 @@
 open module build.spawn.platform.local.jdk {
     requires com.google.auto.service;
 
+    requires transitive build.base.foundation;
+
     requires transitive build.spawn.application;
     requires transitive build.spawn.jdk;
     requires transitive build.spawn.platform.local;

--- a/spawn-local-jdk/src/main/resources/java.home.properties
+++ b/spawn-local-jdk/src/main/resources/java.home.properties
@@ -18,16 +18,32 @@
 # #L%
 ###
 #
-# Defines mappings to JDK installation paths (aka: Java Homes)
+# Defines operating-system-specific rules to detect JDK installation paths (Java Homes).
 #
-# Paths must be absolute. They may contain globs, allowing the definition of patterns for paths.
-# For example, the following mapping defines JDK paths on macOS for zulu
+# Each line defines a rule consisting of a unique OS-specific key, an =, and a glob pattern
+# for the absolute path to a possible Java Home.
 #
-#   macos-zulu = /Library/Java/JavaVirtualMachines/zulu-*.jdk/Contents/Home
+# Key format: <os-pattern>@<unique-name> = <glob>
+#
+#   os-pattern  lower-case kind: mac, windows, unix, posix, unknown ? or a regex matching os.name
+#   unique-name any unique string (no spaces)
+#   glob        absolute path, may include *, **, ?, [...] ? and ${user.home} for the user's home dir
+#
+# Lines without an @ are OS-independent and always evaluated.
 #
 
-macos-zulu = /Library/Java/JavaVirtualMachines/zulu-*.jdk/Contents/Home
-macos-java = /Library/Java/JavaVirtualMachines/jdk*.jdk/Contents/Home
-standard-linux-java = /usr/lib/jvm/java-*
-usr-local-jdk = /usr/local/*jdk*
-usr-local-java = /usr/local/*java*
+mac@zulu           = /Library/Java/JavaVirtualMachines/zulu-*.jdk/Contents/Home
+mac@java           = /Library/Java/JavaVirtualMachines/jdk*.jdk/Contents/Home
+mac@azul           = /Library/Java/JavaVirtualMachines/azul-*/Contents/Home
+mac@zulu-user      = ${user.home}/Library/Java/JavaVirtualMachines/zulu-*.jdk/Contents/Home
+mac@java-user      = ${user.home}/Library/Java/JavaVirtualMachines/jdk*.jdk/Contents/Home
+mac@azul-user      = ${user.home}/Library/Java/JavaVirtualMachines/azul-*/Contents/Home
+mac@sdkman         = ${user.home}/.sdkman/candidates/java/*/Contents/Home
+mac@homebrew       = /opt/homebrew/opt/openjdk*/libexec/openjdk.jdk/Contents/Home
+mac@homebrew-user  = ${user.home}/homebrew/opt/openjdk*/libexec/openjdk.jdk/Contents/Home
+
+unix@java          = /usr/lib/jvm/java-*
+unix@local-jdk     = /usr/local/*jdk*
+unix@local-java    = /usr/local/*java*
+unix@sdkman        = ${user.home}/.sdkman/candidates/java/*
+unix@homebrew      = /home/linuxbrew/.linuxbrew/opt/openjdk*/libexec

--- a/spawn-local-jdk/src/test/java/build/spawn/platform/local/jdk/JDKDetectorTests.java
+++ b/spawn-local-jdk/src/test/java/build/spawn/platform/local/jdk/JDKDetectorTests.java
@@ -1,9 +1,14 @@
 package build.spawn.platform.local.jdk;
 
+import build.base.foundation.Exceptional;
 import build.spawn.jdk.JDK;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 /**
  * Tests for {@link JDKDetector}s.
@@ -52,5 +57,50 @@ class JDKDetectorTests {
             .isPresent();
 
         System.out.println("Detected Default JDK: " + jdk.get());
+    }
+
+    /**
+     * Ensure {@link JDKDetector#paths()} returns the paths to the installed {@link JDK}s.
+     */
+    @Test
+    void shouldReturnPathsForInstalledJDKs() {
+        assertThat(JDKDetector.stream()
+            .flatMap(JDKDetector::paths)
+            .peek(path -> System.out.println("Path: " + path)))
+            .isNotEmpty();
+    }
+
+    /**
+     * Ensure {@link JDKDetector#of(Path)} returns a present {@link Exceptional} for a known-good JDK home.
+     */
+    @Test
+    void shouldDetectJDKAtCurrentJavaHome() {
+        final var home = Path.of(System.getProperty("java.home"));
+
+        final Exceptional<JDK> result = JDKDetector.of(home);
+
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.orElseThrow().home().get()).isNotNull();
+    }
+
+    /**
+     * Ensure {@link JDKDetector#of(Path)} returns an empty {@link Exceptional} for a path that does not exist.
+     */
+    @Test
+    void shouldReturnEmptyExceptionalForNonExistentPath() {
+        final Exceptional<JDK> result = JDKDetector.of(Path.of("/nonexistent/path/to/jdk"));
+
+        assertThat(result.isPresent()).isFalse();
+    }
+
+    /**
+     * Ensure {@link JDKDetector#of(Path)} returns an empty {@link Exceptional} for a directory that has no
+     * {@code bin/java}.
+     */
+    @Test
+    void shouldReturnEmptyExceptionalForDirectoryWithoutBinJava(@TempDir final Path tempDir) {
+        final Exceptional<JDK> result = JDKDetector.of(tempDir);
+
+        assertThat(result.isPresent()).isFalse();
     }
 }

--- a/spawn-local-jdk/src/test/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetectorOSTests.java
+++ b/spawn-local-jdk/src/test/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetectorOSTests.java
@@ -1,0 +1,86 @@
+package build.spawn.platform.local.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for OS pattern matching in {@link JDKHomeBasedPatternDetector}.
+ *
+ * @author brian.oliver
+ * @since Mar-2026
+ */
+class JDKHomeBasedPatternDetectorOSTests {
+
+    /**
+     * Ensure the {@code mac} pattern matches Mac OS X.
+     */
+    @Test
+    void shouldMatchMacPattern() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("Mac OS X", "mac"))
+            .isTrue();
+    }
+
+    /**
+     * Ensure the {@code windows} pattern matches Windows 10.
+     */
+    @Test
+    void shouldMatchWindowsPattern() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("Windows 10", "windows"))
+            .isTrue();
+    }
+
+    /**
+     * Ensure the {@code unix} pattern matches Linux.
+     */
+    @Test
+    void shouldMatchUnixPatternForLinux() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("Linux", "unix"))
+            .isTrue();
+    }
+
+    /**
+     * Ensure the {@code unix} pattern matches FreeBSD.
+     */
+    @Test
+    void shouldMatchUnixPatternForFreeBSD() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("FreeBSD", "unix")).
+            isTrue();
+    }
+
+    /**
+     * Ensure the {@code posix} pattern matches SunOS.
+     */
+    @Test
+    void shouldMatchPosixPatternForSolaris() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("SunOS", "posix"))
+            .isTrue();
+    }
+
+    /**
+     * Ensure the {@code mac} pattern does not match Linux.
+     */
+    @Test
+    void shouldNotMatchMacPatternForLinux() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("Linux", "mac"))
+            .isFalse();
+    }
+
+    /**
+     * Ensure the {@code windows} pattern does not match Mac OS X.
+     */
+    @Test
+    void shouldNotMatchWindowsPatternForMac() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("Mac OS X", "windows"))
+            .isFalse();
+    }
+
+    /**
+     * Ensure a regex pattern is matched against the OS name.
+     */
+    @Test
+    void shouldMatchRegexPattern() {
+        assertThat(JDKHomeBasedPatternDetector.matchesOS("Mac OS X", "mac.*"))
+            .isTrue();
+    }
+}


### PR DESCRIPTION
Fixes #1 

### Summary
Ports and improves JDK detection from spin, eliminating the subprocess-based approach entirely.

### JDKDetector.of(Path) — no more subprocess
Previously launched java -version as a child process to verify and version-detect each JDK installation. Now reads the release metadata file directly — faster, no LocalMachine dependency, no risk of launching the wrong JVM. Return type upgraded from Optional<JDK> to Exceptional<JDK> to preserve failure context.

### JDKDetector.detectDefault() — simplified
Reduced to a one-liner: of(Path.of(System.getProperty("java.home"))).optional().

### New JDKDetector.paths() default method
Separates cheap candidate path discovery (glob scanning only) from full metadata loading. Callers that only need to check JDK presence can call paths() without paying the cost of reading each release file.

### OS-aware glob pattern scanning (ported from spin)
JDKHomeBasedPatternDetector now implements paths() with OS-scoped rules from java.home.properties. The new key format <os-pattern>@<unique-name> gates each entry to the current OS (mac, windows, unix, posix, or a regex fallback). Patterns support ${user.home} expansion. Coverage added for sdkman and Homebrew on both macOS and Linux.

detect() now delegates to paths(), eliminating the previously duplicated file-walking logic.

### Tests
JDKDetectorTests: new cases for paths() and the Exceptional-returning of(Path)
JDKHomeBasedPatternDetectorOSTests: unit tests for matchesOS() covering all OS kind patterns