### PR TITLE
fix(spawn-local-jdk, spawn-docker-okhttp): Linux JDK detection and Docker Desktop socket compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Maven build output
+target/
+.flattened-pom.xml
+
+# IntelliJ IDEA
+.idea/
+*.iml

--- a/spawn-docker-okhttp/src/main/java/build/spawn/docker/okhttp/UnixDomainSocketBasedSession.java
+++ b/spawn-docker-okhttp/src/main/java/build/spawn/docker/okhttp/UnixDomainSocketBasedSession.java
@@ -58,7 +58,27 @@ public class UnixDomainSocketBasedSession
     /**
      * The {@code docker.sock} {@link File}.
      */
-    private static final File DOCKER_SOCK_FILE = new File("/var/run/docker.sock");
+    private static final File DOCKER_SOCK_FILE = resolveDockerSockFile();
+
+    /**
+     * Resolves the {@code docker.sock} {@link File} by checking known locations in order of preference.
+     *
+     * @return the {@code docker.sock} {@link File}
+     */
+    private static File resolveDockerSockFile() {
+        final var candidates = new java.util.ArrayList<File>();
+
+        // Docker Desktop on Linux
+        candidates.add(new File(System.getProperty("user.home") + "/.docker/desktop/docker.sock"));
+
+        // standard Docker Engine location
+        candidates.add(new File("/var/run/docker.sock"));
+
+        return candidates.stream()
+            .filter(File::exists)
+            .findFirst()
+            .orElse(new File("/var/run/docker.sock"));
+    }
 
     /**
      * Constructs a {@link UnixDomainSocketBasedSession} using the specified {@link Configuration}.

--- a/spawn-local-jdk/src/main/resources/java.home.properties
+++ b/spawn-local-jdk/src/main/resources/java.home.properties
@@ -43,6 +43,8 @@ mac@homebrew       = /opt/homebrew/opt/openjdk*/libexec/openjdk.jdk/Contents/Hom
 mac@homebrew-user  = ${user.home}/homebrew/opt/openjdk*/libexec/openjdk.jdk/Contents/Home
 
 unix@java          = /usr/lib/jvm/java-*
+unix@jdk           = /usr/lib/jvm/jdk-*
+unix@zulu          = /usr/lib/jvm/zulu*
 unix@local-jdk     = /usr/local/*jdk*
 unix@local-java    = /usr/local/*java*
 unix@sdkman        = ${user.home}/.sdkman/candidates/java/*


### PR DESCRIPTION
- Added unix@jdk and unix@zulu glob patterns to java.home.properties to detect JDKs installed as jdk-* and zulu* under /usr/lib/jvm
- Fixed UnixDomainSocketBasedSession to prefer ~/.docker/desktop/docker.sock over /var/run/docker.sock, so Docker Desktop for Linux works correctly

see https://github.com/Workday/codemodel.build/pull/1