### PR TITLE
chore: add GitHub Actions workflows for CI, snapshots, and releases

### DIFF
--- a/.github/workflows/main-pull-request.yml
+++ b/.github/workflows/main-pull-request.yml
@@ -1,0 +1,49 @@
+name: Main Pull Request
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Get cache week
+        id: date
+        run: echo "week=$(date +%Y-%W)" >> $GITHUB_OUTPUT
+
+      - name: Cache Docker images
+        id: cache-docker
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-images
+          key: docker-images-${{ runner.os }}-${{ steps.date.outputs.week }}
+          restore-keys: |
+            docker-images-${{ runner.os }}-
+
+      - name: Load cached Docker images
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-images/images.tar
+
+      - name: Pull and save Docker images
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+        run: |
+          docker pull alpine:latest
+          docker pull nginx:latest
+          docker pull rabbitmq:latest
+          mkdir -p /tmp/docker-images
+          docker save alpine:latest nginx:latest rabbitmq:latest -o /tmp/docker-images/images.tar
+
+      - name: Build and Test
+        run: ./mvnw clean install

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,60 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          cache: 'maven'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Get cache week
+        id: date
+        run: echo "week=$(date +%Y-%W)" >> $GITHUB_OUTPUT
+
+      - name: Cache Docker images
+        id: cache-docker
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-images
+          key: docker-images-${{ runner.os }}-${{ steps.date.outputs.week }}
+          restore-keys: |
+            docker-images-${{ runner.os }}-
+
+      - name: Load cached Docker images
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-images/images.tar
+
+      - name: Pull and save Docker images
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+        run: |
+          docker pull alpine:latest
+          docker pull nginx:latest
+          docker pull rabbitmq:latest
+          mkdir -p /tmp/docker-images
+          docker save alpine:latest nginx:latest rabbitmq:latest -o /tmp/docker-images/images.tar
+
+      - name: Publish Snapshot
+        run: ./mvnw clean deploy
+        env:
+          MAVEN_PUBLISH: "true"
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Release version (e.g. 1.0.0) — leave blank to use current POM version without -SNAPSHOT'
+        required: false
+      next-version:
+        description: 'Next development version (e.g. 1.0.1-SNAPSHOT) — leave blank to use incremented patch version with -SNAPSHOT'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          cache: 'maven'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Get cache week
+        id: date
+        run: echo "week=$(date +%Y-%W)" >> $GITHUB_OUTPUT
+
+      - name: Cache Docker images
+        id: cache-docker
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-images
+          key: docker-images-${{ runner.os }}-${{ steps.date.outputs.week }}
+          restore-keys: |
+            docker-images-${{ runner.os }}-
+
+      - name: Load cached Docker images
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-images/images.tar
+
+      - name: Pull and save Docker images
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+        run: |
+          docker pull alpine:latest
+          docker pull nginx:latest
+          docker pull rabbitmq:latest
+          mkdir -p /tmp/docker-images
+          docker save alpine:latest nginx:latest rabbitmq:latest -o /tmp/docker-images/images.tar
+
+      - name: Determine Versions
+        id: versions
+        run: |
+          CURRENT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+          RELEASE_VERSION="${{ inputs.release-version }}"
+          if [ -z "$RELEASE_VERSION" ]; then
+            RELEASE_VERSION="${CURRENT_VERSION/-SNAPSHOT/}"
+          fi
+
+          NEXT_VERSION="${{ inputs.next-version }}"
+          if [ -z "$NEXT_VERSION" ]; then
+            PATCH=$(echo "$RELEASE_VERSION" | cut -d. -f3)
+            NEXT_PATCH=$((PATCH + 1))
+            NEXT_VERSION=$(echo "$RELEASE_VERSION" | sed "s/\.[0-9]*$/.${NEXT_PATCH}-SNAPSHOT/")
+          fi
+
+          echo "release-version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "next-version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create Release Branch
+        run: git checkout -b release-${{ steps.versions.outputs.release-version }}
+
+      - name: Set Release Version
+        run: |
+          ./mvnw versions:set-property \
+            -Dproperty=revision \
+            -DnewVersion=${{ steps.versions.outputs.release-version }} \
+            -DgenerateBackupPoms=false
+
+      - name: Build and Deploy Release
+        run: ./mvnw clean deploy
+        env:
+          MAVEN_PUBLISH: "true"
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Commit and Tag Release
+        run: |
+          git add pom.xml
+          git commit -m "Release ${{ steps.versions.outputs.release-version }}"
+          git tag -a v${{ steps.versions.outputs.release-version }} -m "Release ${{ steps.versions.outputs.release-version }}"
+
+      - name: Set Next Development Version
+        run: |
+          ./mvnw versions:set-property \
+            -Dproperty=revision \
+            -DnewVersion=${{ steps.versions.outputs.next-version }} \
+            -DgenerateBackupPoms=false
+
+      - name: Commit Next Development Version
+        run: |
+          git add pom.xml
+          git commit -m "Prepare for next development iteration ${{ steps.versions.outputs.next-version }}"
+
+      - name: Push Release Branch and Tag
+        run: git push --follow-tags origin release-${{ steps.versions.outputs.release-version }}
+
+      - name: Open and Merge PR to main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head release-${{ steps.versions.outputs.release-version }} \
+            --title "Prepare for development of ${{ steps.versions.outputs.next-version }}" \
+            --body "Prepares next development iteration **${{ steps.versions.outputs.next-version }}**.")
+
+          gh pr merge "$PR_URL" --squash

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
         <mockito.version>5.23.0</mockito.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <codemodel.version>0.19.0-SNAPSHOT</codemodel.version>
+        <codemodel.version>0.19.0</codemodel.version>
 
         <!-- Plugin Dependency Versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
     <packaging>pom</packaging>
 
     <name>Spawn Project</name>
+    <description>A Java-based multi-module framework for programmatically launching and controlling processes, JVMs, and Docker containers.</description>
+    <url>https://github.com/Workday/spawn.build</url>
 
     <organization>
         <name>Workday, Inc.</name>
@@ -31,6 +33,15 @@
         <developer>
             <name>Brian Oliver</name>
             <email>brian.oliver@workday.com</email>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+            </roles>
+        </developer>
+
+        <developer>
+            <name>Reed von Redwitz</name>
+            <email>reed.vonredwitz@workday.com</email>
             <roles>
                 <role>architect</role>
                 <role>developer</role>
@@ -60,7 +71,7 @@
         <auto-service.version>1.1.1</auto-service.version>
         <base.version>0.21.5</base.version>
         <byte-buddy.version>1.18.4</byte-buddy.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson-core.version>2.21.2</jackson-core.version>
         <junit.version>6.0.3</junit.version>
         <junixsocket.version>2.10.1</junixsocket.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
@@ -119,6 +130,8 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <parameters>true</parameters>
+                    <testCompilerArgument>-parameters</testCompilerArgument>
                 </configuration>
             </plugin>
 
@@ -168,6 +181,7 @@
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>${maven-flatten-plugin.version}</version>
                 <configuration>
+                    <flattenMode>ossrh</flattenMode>
                     <updatePomFile>true</updatePomFile>
                 </configuration>
                 <executions>
@@ -323,6 +337,16 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/spawn-docker-okhttp/pom.xml
+++ b/spawn-docker-okhttp/pom.xml
@@ -103,13 +103,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-core.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-core.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/spawn-docker/pom.xml
+++ b/spawn-docker/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-core.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
+++ b/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
@@ -145,12 +145,22 @@ public class JDKHomeBasedPatternDetector
 
                                 final ArrayList<Path> paths = new ArrayList<>();
 
+                                // compute max walk depth from the pattern suffix — patterns without **
+                                // can only match at a fixed depth, so there's no need to go deeper.
+                                // +1 because Files.walkFileTree calls preVisitDirectory for depths
+                                // 0..maxDepth-1 only; at exactly maxDepth, directories are delivered
+                                // via visitFile and our preVisitDirectory check never fires.
+                                final String patternSuffix = pattern.substring(lastPathSeparator);
+                                final int maxDepth = patternSuffix.contains("**")
+                                    ? Integer.MAX_VALUE
+                                    : (int) patternSuffix.chars().filter(c -> c == '/').count() + 1;
+
                                 // attempt to find paths matching the glob, iff the base path exists
                                 if (base.toFile().exists()) {
                                     Files.walkFileTree(
                                         base,
                                         EnumSet.of(FileVisitOption.FOLLOW_LINKS),
-                                        Integer.MAX_VALUE,
+                                        maxDepth,
                                         new SimpleFileVisitor<Path>() {
                                             @Override
                                             public FileVisitResult preVisitDirectory(final Path path,

--- a/spawn-local-jdk/src/main/resources/java.home.properties
+++ b/spawn-local-jdk/src/main/resources/java.home.properties
@@ -49,3 +49,4 @@ unix@local-jdk     = /usr/local/*jdk*
 unix@local-java    = /usr/local/*java*
 unix@sdkman        = ${user.home}/.sdkman/candidates/java/*
 unix@homebrew      = /home/linuxbrew/.linuxbrew/opt/openjdk*/libexec
+unix@github-actions = /opt/hostedtoolcache/Java_*/*/*


### PR DESCRIPTION
Adds three GitHub Actions workflows:
                                                                                                                                                                                                                                                           
- main-pull-request.yml — builds and tests every PR targeting main (./mvnw clean install, Java 25 Zulu)
- publish-snapshot.yml — publishes a snapshot to Maven Central on every push to main, and on manual trigger                                                                                                                                                
- release.yml — manual workflow that sets the release version, builds and deploys to Maven Central, tags the commit, bumps to the next development version, and opens a PR back to main; release and next versions can be overridden via inputs or derived automatically from the current POM version