### PR TITLE
chore: standardize README and fix SECURITY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Spawn is a Java 25 framework for programmatically launching and controlling processes, JVMs, and Docker containers. It provides a unified abstraction (`Platform` / `Application` / `Process`) over different execution environments. The core pattern: define a `Specification`, call `platform.launch(spec)`, get back an `Application` with `CompletableFuture`-based lifecycle hooks.
 
-**Stack**: Java 25, Maven, Jackson, junixsocket, `build.base.*` and `build.codemodel.injection`
+**Stack**: Java 25, Maven, Jackson, `build.base.*` and `build.codemodel.injection`
 
 **Structure**: 8 Maven modules in a monorepo, each mapping to a JPMS module:
 - `spawn-option` → shared option types
@@ -14,7 +14,7 @@ Spawn is a Java 25 framework for programmatically launching and controlling proc
 - `spawn-local-platform` → local OS process launcher (`LocalMachine`)
 - `spawn-local-jdk` → JDK detection + `LocalJDKLauncher`
 - `spawn-docker` → Docker Engine API interfaces
-- `spawn-docker-jdk` → JDK HTTP Client-based Docker implementation (uses `java.net.http` + junixsocket)
+- `spawn-docker-jdk` → JDK HTTP Client-based Docker implementation (uses `java.net.http`)
 
 For detailed architecture, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Spawn is a Java 25 framework for programmatically launching and controlling processes, JVMs, and Docker containers. It provides a unified abstraction (`Platform` / `Application` / `Process`) over different execution environments. The core pattern: define a `Specification`, call `platform.launch(spec)`, get back an `Application` with `CompletableFuture`-based lifecycle hooks.
 
-**Stack**: Java 25, Maven, Jackson, junixsocket, proprietary `build.base.*` and `build.codemodel.injection`
+**Stack**: Java 25, Maven, Jackson, junixsocket, `build.base.*` and `build.codemodel.injection`
 
 **Structure**: 8 Maven modules in a monorepo, each mapping to a JPMS module:
 - `spawn-option` → shared option types
@@ -32,5 +32,4 @@ Tests requiring Docker are gated by `@EnabledIf("isDockerAvailable")`. The `spaw
 - All option types are immutable with static `of(...)` factories and `@Default` annotated defaults
 - `Customizer` inner classes on `Application` interfaces are auto-discovered and applied at launch
 - Launcher registry: `META-INF/<PlatformClassName>` properties files map `Application=Launcher`
-- Use `Brian Oliver Java style` for all code in this repo (see `brian-oliver-java-style` skill)
 - Checkstyle enforced: no tabs, no star imports, final locals, no asserts, braces required

--- a/README.md
+++ b/README.md
@@ -1,43 +1,96 @@
 # spawn
+A Java framework for programmatically launching and controlling processes, JVMs, and Docker containers.
 
-build.spawn: A framework to programmatically launch and control processes, applications, services and containers
+[![CI](https://github.com/Workday/spawn.build/actions/workflows/main-pull-request.yml/badge.svg)](https://github.com/Workday/spawn.build/actions/workflows/main-pull-request.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/build.spawn/spawn-application)](https://central.sonatype.com/artifact/build.spawn/spawn-application)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-When using this framework to launch Docker containers, the following JVM command-line argument must be added
-(with Java 25+):
+## Overview
+
+`spawn` provides a unified abstraction over local processes, JVMs, and Docker containers. Define a
+`Specification`, call `platform.launch(spec)`, and get back an `Application` with
+`CompletableFuture`-based lifecycle hooks — regardless of the underlying execution environment.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `spawn-option` | Shared option types |
+| `spawn-application` | Core abstractions: Platform, Application, Process, Specification, Customizer |
+| `spawn-application-composition` | Multi-application topology management |
+| `spawn-jdk` | JDK launch abstractions and SpawnAgent for two-way JVM communication |
+| `spawn-local-platform` | Local OS process launcher (`LocalMachine`) |
+| `spawn-local-jdk` | JDK detection and `LocalJDKLauncher` |
+| `spawn-docker` | Docker Engine API interfaces |
+| `spawn-docker-jdk` | JDK HTTP Client-based Docker implementation (unix socket via junixsocket) |
+
+## Requirements
+
+- Java 25+
+- Maven (wrapper included — no separate install needed)
+- Docker (only required for `spawn-docker` / `spawn-docker-jdk` modules)
+
+## Using this Library
+
+Add individual modules as dependencies. All modules share the same version:
+
+```xml
+<dependency>
+    <groupId>build.spawn</groupId>
+    <artifactId>spawn-application</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+Replace `VERSION` with the latest version shown in the Maven Central badge above.
+
+When using the Docker modules, add the following JVM flag (Java 25+):
+
+```
+--enable-native-access=ALL-UNNAMED
+```
+
+On macOS and Linux, access to the Docker socket may require a permissions adjustment:
 
 ```bash
-    --enable-native-access=ALL-UNNAMED
-```
-
-On MacOS (and linux), local machine access to the Docker Engine may be restricted to prevent read and write access to
-the docker.socket. To ensure access to the Docker Engine, the permissions for the following files may need to be
-increase.
-
-```
 sudo chmod 660 ~/Library/Containers/com.docker.docker/Data/docker.raw.sock
-```
-
-and
-
-```
 sudo chmod 660 /var/run/docker.sock
 ```
 
-It's also possible that the symbolic link to `/var/run/docker.sock` may need to be recreated.
+If `/var/run/docker.sock` is missing, recreate the symlink:
 
-```
+```bash
 sudo ln -s ~/Library/Containers/com.docker.docker/Data/docker.raw.sock /var/run/docker.sock
 ```
 
-## Running Tests
+## Building from Source
 
-The Docker integration tests (`SessionTests`) require several images to be present in the local Docker cache before running. 
+```bash
+./mvnw clean install
+```
 
-Pre-pull them once using:
+To build a custom version:
+
+```bash
+./mvnw -Drevision=x.y.z-SNAPSHOT-my-name clean install
+```
+
+### Running Tests
+
+Docker integration tests require several images to be present in the local cache. Pre-pull them once before running:
 
 ```bash
 docker pull alpine:latest && docker pull rabbitmq:latest && docker pull nginx:latest
 ```
 
-Without this step, the test setup (`@BeforeAll`) will attempt to pull these images on demand, which blocks the tests 
-for several minutes and may fail due to transient registry (timeout) errors.
+## Contributing
+
+Code style is enforced by Checkstyle: no tabs, no star imports, final locals and parameters, braces
+required on all blocks, no `assert` statements. Import order: third-party, standard Java, then
+static. IntelliJ configuration is at `config/intellij/CodeStyle.xml`.
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Java framework for programmatically launching and controlling processes, JVMs,
 | `spawn-local-platform` | Local OS process launcher (`LocalMachine`) |
 | `spawn-local-jdk` | JDK detection and `LocalJDKLauncher` |
 | `spawn-docker` | Docker Engine API interfaces |
-| `spawn-docker-jdk` | JDK HTTP Client-based Docker implementation (unix socket via junixsocket) |
+| `spawn-docker-jdk` | JDK HTTP Client-based Docker implementation |
 
 ## Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ This is a Workday sponsored project hosted on GitHub.
 
 To report a security vulnerability, please **do not** open a public GitHub issue. Instead:
 
-1. Navigate to the [Security Advisories](https://https://github.com/workday/spawn.build/security/advisories) page for
+1. Navigate to the [Security Advisories](https://github.com/workday/spawn.build/security/advisories) page for
    this repository and click **Report a vulnerability**.
 
 2. Alternatively, contact the project maintainers directly by emailing the developers.

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -372,7 +372,7 @@ Server (listens on spawn:// URI)
 
 ## Conventions
 
-### Brian Oliver Java Style
+### Code Style
 - No tabs (spaces only), enforced by Checkstyle
 - No star imports
 - Final locals where possible


### PR DESCRIPTION
- Rewrites README using shared template; preserves Docker socket setup and test pre-pull instructions
- Removes "Brian Oliver Java style" name and "proprietary" label from CLAUDE.md and CODEBASE_MAP.md
- Fixes broken https://https:// link in SECURITY.md