### PR TITLE
chore(spawn-local-jdk): replace auto-service with native JPMS service registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 # IntelliJ IDEA
 .idea/
 *.iml
+
+.build/

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,13 @@
 
         <!-- Module Dependency Versions -->
         <assertj.version>3.27.7</assertj.version>
-        <auto-service.version>1.1.1</auto-service.version>
         <base.version>0.21.5</base.version>
         <byte-buddy.version>1.18.4</byte-buddy.version>
+        <codemodel.version>0.19.0</codemodel.version>
         <jackson-core.version>2.21.2</jackson-core.version>
         <junit.version>6.0.3</junit.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
         <mockito.version>5.23.0</mockito.version>
-        <codemodel.version>0.19.0</codemodel.version>
 
         <!-- Plugin Dependency Versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -340,9 +339,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <useModulePath>false</useModulePath>
-                </configuration>
             </plugin>
 
         </plugins>

--- a/spawn-local-jdk/pom.xml
+++ b/spawn-local-jdk/pom.xml
@@ -19,12 +19,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.auto.service</groupId>
-            <artifactId>auto-service-annotations</artifactId>
-            <version>${auto-service.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>build.spawn</groupId>
             <artifactId>spawn-application</artifactId>
             <version>${revision}</version>
@@ -152,18 +146,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.auto.service</groupId>
-                            <artifactId>auto-service</artifactId>
-                            <version>${auto-service.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
+++ b/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
@@ -25,7 +25,6 @@ import build.base.expression.Variable;
 import build.base.foundation.Exceptional;
 import build.base.logging.Logger;
 import build.spawn.jdk.JDK;
-import com.google.auto.service.AutoService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,7 +54,6 @@ import java.util.stream.Stream;
  * @author brian.oliver
  * @since Nov-2019
  */
-@AutoService(JDKDetector.class)
 public class JDKHomeBasedPatternDetector
     implements JDKDetector {
 

--- a/spawn-local-jdk/src/main/java/module-info.java
+++ b/spawn-local-jdk/src/main/java/module-info.java
@@ -24,8 +24,6 @@
  * @since Jan-2025
  */
 open module build.spawn.platform.local.jdk {
-    requires com.google.auto.service;
-
     requires java.logging;
 
     requires transitive build.base.foundation;


### PR DESCRIPTION
- Removes the com.google.auto.service dependency and `@AutoService(JDKDetector.class)` annotation from JDKHomeBasedPatternDetector — the module-info.java provides declaration already handles service registration on the module path, making it redundant  
- Removes <useModulePath>false</useModulePath> from the surefire config so tests now run correctly on the module path instead of bypassing JPMS
- Cleans up auto-service.version property from the root pom.xml