### PR TITLE
chore: uptake base 0.22.0 and codemodel 0.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
 
         <!-- Module Dependency Versions -->
         <assertj.version>3.27.7</assertj.version>
-        <base.version>0.21.5</base.version>
+        <base.version>0.22.0</base.version>
         <byte-buddy.version>1.18.4</byte-buddy.version>
-        <codemodel.version>0.19.0</codemodel.version>
+        <codemodel.version>0.20.0</codemodel.version>
         <jackson-core.version>2.21.2</jackson-core.version>
         <junit.version>6.0.3</junit.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>

--- a/spawn-application-composition/src/main/java/build/spawn/application/composition/option/ApplicationIdentifier.java
+++ b/spawn-application-composition/src/main/java/build/spawn/application/composition/option/ApplicationIdentifier.java
@@ -22,8 +22,8 @@ package build.spawn.application.composition.option;
 
 import build.base.configuration.AbstractValueOption;
 import build.base.configuration.Option;
-import build.base.expression.Resolvable;
-import build.base.expression.Variable;
+import build.base.expression.compat.Resolvable;
+import build.base.expression.compat.Variable;
 import build.spawn.application.Application;
 import build.spawn.application.composition.Composition;
 

--- a/spawn-application/src/main/java/build/spawn/application/AbstractTemplatedPlatform.java
+++ b/spawn-application/src/main/java/build/spawn/application/AbstractTemplatedPlatform.java
@@ -22,10 +22,10 @@ package build.spawn.application;
 
 import build.base.configuration.Configuration;
 import build.base.configuration.ConfigurationBuilder;
-import build.base.expression.Processor;
-import build.base.expression.ProcessorBuilder;
-import build.base.expression.Resolvable;
-import build.base.expression.Variable;
+import build.base.expression.compat.Processor;
+import build.base.expression.compat.ProcessorBuilder;
+import build.base.expression.compat.Resolvable;
+import build.base.expression.compat.Variable;
 import build.base.foundation.Introspection;
 import build.base.foundation.Preconditions;
 import build.base.foundation.Strings;

--- a/spawn-application/src/main/java/build/spawn/application/option/Argument.java
+++ b/spawn-application/src/main/java/build/spawn/application/option/Argument.java
@@ -23,7 +23,7 @@ package build.spawn.application.option;
 import build.base.configuration.AbstractValueOption;
 import build.base.configuration.CollectedOption;
 import build.base.configuration.Option;
-import build.base.expression.Processor;
+import build.base.expression.compat.Processor;
 import build.base.expression.option.ResolvableOption;
 import build.spawn.application.Application;
 

--- a/spawn-jdk/src/main/java/build/spawn/jdk/option/JDKOption.java
+++ b/spawn-jdk/src/main/java/build/spawn/jdk/option/JDKOption.java
@@ -25,7 +25,7 @@ import build.base.configuration.CollectedOption;
 import build.base.configuration.Configuration;
 import build.base.configuration.ConfigurationBuilder;
 import build.base.configuration.Option;
-import build.base.expression.Processor;
+import build.base.expression.compat.Processor;
 import build.base.expression.option.ResolvableOption;
 import build.base.option.JDKVersion;
 import build.spawn.application.Platform;

--- a/spawn-jdk/src/main/java/build/spawn/jdk/option/SystemProperty.java
+++ b/spawn-jdk/src/main/java/build/spawn/jdk/option/SystemProperty.java
@@ -23,7 +23,7 @@ package build.spawn.jdk.option;
 import build.base.configuration.ConfigurationBuilder;
 import build.base.configuration.MappedOption;
 import build.base.configuration.Option;
-import build.base.expression.Processor;
+import build.base.expression.compat.Processor;
 import build.base.expression.option.ResolvableOption;
 import build.base.foundation.Strings;
 import build.base.table.Table;

--- a/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
+++ b/spawn-local-jdk/src/main/java/build/spawn/platform/local/jdk/JDKHomeBasedPatternDetector.java
@@ -20,8 +20,8 @@ package build.spawn.platform.local.jdk;
  * #L%
  */
 
-import build.base.expression.Processor;
-import build.base.expression.Variable;
+import build.base.expression.compat.Processor;
+import build.base.expression.compat.Variable;
 import build.base.foundation.Exceptional;
 import build.base.logging.Logger;
 import build.spawn.jdk.JDK;

--- a/spawn-option/src/main/java/build/spawn/option/EnvironmentVariable.java
+++ b/spawn-option/src/main/java/build/spawn/option/EnvironmentVariable.java
@@ -22,7 +22,7 @@ package build.spawn.option;
 
 import build.base.configuration.MappedOption;
 import build.base.configuration.Option;
-import build.base.expression.Processor;
+import build.base.expression.compat.Processor;
 import build.base.expression.option.ResolvableOption;
 import build.base.table.Table;
 import build.base.table.Tabular;


### PR DESCRIPTION
Bumps base from 0.21.5 → 0.22.0 and codemodel from 0.19.0 → 0.20.0.
 
The base 0.22.0 uptake includes migrating all expression imports from build.base.expression.* to the new build.base.expression.compat.* package, which preserves the existing API while accommodating the native Jakarta EL 6.0 implementation introduced in that release.