### PR TITLE
chore(spawn-jdk): make ClassPathTests robust when JVM is launched on module path only

### DIFF
--- a/spawn-jdk/src/test/java/build/spawn/jdk/option/ClassPathTests.java
+++ b/spawn-jdk/src/test/java/build/spawn/jdk/option/ClassPathTests.java
@@ -30,21 +30,27 @@ class ClassPathTests {
 
     /**
      * Ensure a {@link ClassPath} can be created based on the Virtual Machine.
+     * When the JVM is launched purely on the module path (e.g. under spin), {@code java.class.path}
+     * is empty and {@link ClassPath#inherited()} correctly returns an empty {@link ClassPath}.
      */
     @Test
     void shouldCreateSystemClassPath() {
         final ClassPath classPath = ClassPath.inherited();
 
-        // there's no way the current ClassPath can be empty
-        assertThat(classPath)
-            .isNotEmpty();
+        // ClassPath.inherited() must exactly reflect java.class.path — empty or not
+        final var systemClassPath = System.getProperty("java.class.path", "");
 
-        // ensure the paths in the ClassPath are in the java class path
-        final var systemClassPath = System.getProperty("java.class.path");
+        if (systemClassPath.isEmpty()) {
+            assertThat(classPath)
+                .isEmpty();
+        } else {
+            assertThat(classPath)
+                .isNotEmpty();
 
-        assertThat(classPath.paths()
-            .filter(path -> systemClassPath.contains(path.toString())))
-            .hasSize(classPath.size());
+            assertThat(classPath.paths()
+                .filter(path -> systemClassPath.contains(path.toString())))
+                .hasSize(classPath.size());
+        }
     }
 
     /**
@@ -52,14 +58,10 @@ class ClassPathTests {
      */
     @Test
     void shouldTreatClassPathAsAPathSet() {
-        // obtain the same Path, multiple times so we have multiple different instances
-        final Path path1 = ClassPath.inherited().stream()
-            .findFirst()
-            .orElseThrow(() -> new RuntimeException("Expected a path"));
-
-        final Path path2 = ClassPath.inherited().stream()
-            .findFirst()
-            .orElseThrow(() -> new RuntimeException("Expected a path"));
+        // use a stable, always-present path rather than the system ClassPath
+        // (which may be empty when the JVM is launched on the module path only)
+        final Path path1 = Path.of(System.getProperty("user.home"));
+        final Path path2 = Path.of(System.getProperty("user.home"));
 
         // create a ClassPath using the same Path multiple times
         final ClassPath classPath = ClassPath.of(path1, path2, path1, path2);


### PR DESCRIPTION
shouldCreateSystemClassPath previously assumed java.class.path is always non-empty, causing it to fail when the JVM is launched purely on the module path (e.g. under spin). The test now reads java.class.path and branches: asserts empty when the system property is empty, otherwise applies the existing non-empty checks.                                                                                                                                                                                       
                                                                                                                                                                                                                                                           
shouldTreatClassPathAsAPathSet had the same fragility — it sourced test paths from ClassPath.inherited(), which throws if the inherited classpath is empty. Replaced with user.home, a stable path that's always present.