### PR TITLE
fix(spawn-application): default lifecycles to empty list in AbstractApplication

### DIFF
--- a/spawn-application/src/main/java/build/spawn/application/AbstractApplication.java
+++ b/spawn-application/src/main/java/build/spawn/application/AbstractApplication.java
@@ -30,6 +30,7 @@ import build.spawn.application.option.StandardOutputFormatter;
 import build.spawn.application.option.StandardOutputSubscriber;
 import jakarta.inject.Inject;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -80,7 +81,7 @@ public abstract class AbstractApplication
      * The {@link Lifecycle}s this {@link Application} must respect.
      */
     @Inject
-    private Iterable<Lifecycle<?>> lifecycles;
+    private Iterable<Lifecycle<?>> lifecycles = List.of();
 
     /**
      * Constructs the {@link Application}.


### PR DESCRIPTION
Initializes the `@Inject`-ed `lifecycles` field to `List.of()` so that iterating it is safe if the binding is absent (e.g., in tests or minimal DI configurations), avoiding a NullPointerException at runtime.